### PR TITLE
Make GitHub detect *.sf as Forth

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ft linguist-language=Forth


### PR DESCRIPTION
 Hello,

Please merge this, if you'd like GitHub to detect your `.ft` files as Forth.

Thank you!  
